### PR TITLE
Refactor Dockerfile to Use a Working Directory for Script Execution

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,14 @@ FROM tailscale/tailscale:latest
 # Install Caddy
 RUN apk update && apk add --no-cache caddy
 
-# Copy start script
-COPY start-tailscale-and-caddy.sh /usr/local/bin/start-tailscale-and-caddy.sh
-RUN chmod +x /usr/local/bin/start-tailscale-and-caddy.sh
+# Create a working directory
+WORKDIR /app
 
-ENTRYPOINT ["/usr/local/bin/start-tailscale-and-caddy.sh"]
+# Copy start script
+COPY start-tailscale-and-caddy.sh /app/start-tailscale-and-caddy.sh
+
+# Ensure the script is executable
+RUN chmod +x /app/start-tailscale-and-caddy.sh
+
+# Set the script as the entry point
+ENTRYPOINT ["/app/start-tailscale-and-caddy.sh"]


### PR DESCRIPTION
This PR refactors the Dockerfile to follow best practices by introducing a working directory for the container. The changes include:

- **Creation of a Working Directory:** Added a `WORKDIR /app` directive to establish a dedicated directory for the application files.
- **Script Placement:** Moved the `start-tailscale-and-caddy.sh` script from `/usr/local/bin/` to `/app/`, aligning with the new working directory.
- **Permissions Update:** Ensured the `start-tailscale-and-caddy.sh` script in `/app/` is executable by adding a `chmod +x` command.
- **Entry Point Adjustment:** Updated the `ENTRYPOINT` to point to the script in the `/app/` directory.

These changes improve the organization and maintainability of the Dockerfile, ensuring a cleaner and more predictable execution environment.