### PR TITLE
Change Script Interpreter from Bash to Sh in `start-tailscale-and-caddy.sh`

### DIFF
--- a/start-tailscale-and-caddy.sh
+++ b/start-tailscale-and-caddy.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # start-tailscale-and-caddy.sh
 
 # Start the Tailscale daemon in the background


### PR DESCRIPTION
This pull request updates the `start-tailscale-and-caddy.sh` script to use `/bin/sh` instead of `/bin/bash` as its interpreter. The change ensures that the script is compatible with environments where only `sh` is available and may improve portability across different systems.

No other changes to the script’s functionality are included in this update.